### PR TITLE
fixes null variables crash

### DIFF
--- a/src/replace-variables.js
+++ b/src/replace-variables.js
@@ -7,6 +7,9 @@ exports.replaceVariables = (html, replacer) => {
 const VARIABLE_REGEX = /^\w+$/;
 exports.validateVariables = variables => {
   // Validate variable names
+  if (!variables) {
+    return;
+  }
   const offending = Object.keys(variables)
     .filter(v => !VARIABLE_REGEX.test(v));
   if (offending.length > 0) {


### PR DESCRIPTION
This change allows you to use the plugin in gatsby-config.js like so

plugins:[
  'gatsby-transformer-html',

Without this fix you will throw an exception as variables is undefined.